### PR TITLE
Update link of GitHub Actions build status badge

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,8 @@
 
 # AddressBook Level-3
 
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
-[![codecov](https://codecov.io/gh/se-edu/addressbook-level3/branch/master/graph/badge.svg)](https://codecov.io/gh/se-edu/addressbook-level3)
+[![CI Status](https://github.com/AY2526S1-CS2103T-F11-4/tp/actions/workflows/gradle.yml/badge.svg)](https://github.com/AY2526S1-CS2103T-F11-4/tp/actions/workflows/gradle.yml)
+[![codecov](https://codecov.io/github/AY2526S1-CS2103T-F11-4/tp/graph/badge.svg?token=C7VKPW98S1)](https://codecov.io/github/AY2526S1-CS2103T-F11-4/tp)
 
 ![Ui](images/Ui.png)
 


### PR DESCRIPTION
Original Link for GitHub Actions build status badge was wrong.

Modified the link to point at our repository instead of the original repository.

Closes: #32 