### PR TITLE
Add CommandHistory Class and corresponding basic test cases

### DIFF
--- a/src/main/java/seedu/address/model/CommandHistory.java
+++ b/src/main/java/seedu/address/model/CommandHistory.java
@@ -1,0 +1,54 @@
+package seedu.address.model;
+
+import java.util.ArrayList;
+
+/**
+ * Represents in-memory Record of Command Usage in order
+ */
+public class CommandHistory implements ReadOnlyCommandHistory {
+
+    /**
+     * Array of stored command strings
+     */
+    private ArrayList<String> commandHistoryList = new ArrayList<>();
+
+    /**
+     * Adds a new command string to commandHistoryList for tracking
+     * Commands are added to the end of the array
+     */
+    public void saveNewCommand(String newCommand) {
+        this.commandHistoryList.add(newCommand);
+    }
+
+    /**
+     * Gets the last command from history
+     * @return Last Command String
+     */
+    public String getLastCommand() {
+        int lastIndex = this.commandHistoryList.size() - 1;
+
+        // Out of Bounds ? Return empty
+        if (lastIndex < 0) {
+            return "";
+        }
+
+        return this.commandHistoryList.get(lastIndex);
+    }
+
+    /**
+     * (Overloaded) Gets the targeted nth command from history
+     * @param n (Zero Indexed) Targets Nth Command in history starting from most recent
+     * @return target Command String
+     */
+    public String getLastCommand(int n) {
+        int targetIndex = this.commandHistoryList.size() - 1 - n;
+
+        // Out of Bounds ? Return Empty String
+        if (targetIndex < 0) {
+            return "";
+        }
+
+        // If index valid, return command string
+        return this.commandHistoryList.get(targetIndex);
+    }
+}

--- a/src/main/java/seedu/address/model/ReadOnlyCommandHistory.java
+++ b/src/main/java/seedu/address/model/ReadOnlyCommandHistory.java
@@ -1,0 +1,14 @@
+package seedu.address.model;
+
+/**
+ * Unmodifiable view of Command History
+ */
+public interface ReadOnlyCommandHistory {
+
+    /**
+     * Takes an index offset value n, and retrieves the nth latest command (zero-indexed)
+     * @return String of target Command (Empty String "" if not found)
+     */
+    String getLastCommand();
+    String getLastCommand(int n);
+}

--- a/src/test/java/seedu/address/model/CommandHistoryTest.java
+++ b/src/test/java/seedu/address/model/CommandHistoryTest.java
@@ -1,0 +1,38 @@
+package seedu.address.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class CommandHistoryTest {
+    @Test
+    public void saveNewCommand_withValidCommandString_savesCommand() {
+        // getLastCommand(n) is also simultaneously tested due to usage
+
+        CommandHistory commandHistory = new CommandHistory();
+        // saves command testN in reverse order as getLastCommand indexes backwards
+        commandHistory.saveNewCommand("test2");
+        commandHistory.saveNewCommand("test1");
+        commandHistory.saveNewCommand("test0"); // Latest Command
+
+        assertEquals("test1", commandHistory.getLastCommand(1));
+        assertEquals("test0", commandHistory.getLastCommand(0));
+        assertEquals("test2", commandHistory.getLastCommand(2));
+    }
+
+
+    @Test
+    public void getLastCommand_emptyOrOutOfBounds_returnsEmptyString() {
+        CommandHistory commandHistory = new CommandHistory();
+
+        String emptyHistoryGetResult = commandHistory.getLastCommand();
+        assertEquals("", emptyHistoryGetResult);
+
+        // Add temporary commands for out of bounds test
+        commandHistory.saveNewCommand("test1");
+        commandHistory.saveNewCommand("test0");
+
+        String outOfBoundsHistoryGetResult = commandHistory.getLastCommand(2);
+        assertEquals("", emptyHistoryGetResult);
+    }
+}


### PR DESCRIPTION
relates to #63 

Added a new class, interface and test cases to the `Model` Component:
- Created a `CommandHistory` class that implements a new `ReadOnlyCommandHistory` interface.
- `CommandHistory` instance will be subsequently be configured to initialise on every runtime.
- `CommandHistory` will be used to keep track (in-memory) of commands user enters.
- Created basic test cases for getting and setting in `CommandHistoryTest`

