### PR TITLE
Fix stuck commandbox bug + Add browse to help

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '7.1.2'
     id 'application'
     id 'jacoco'
+    id 'org.openjfx.javafxplugin' version '0.1.0'
 }
 
 mainClassName = 'seedu.address.Main'
@@ -63,6 +64,11 @@ dependencies {
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: jUnitVersion
 
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion
+}
+
+javafx {
+    version = '17.0.7'
+    modules = [ 'javafx.controls', 'javafx.fxml', 'javafx.graphics', 'javafx.swing' ]
 }
 
 shadowJar {

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -64,11 +64,12 @@ public class CommandBox extends UiPart<Region> {
         if (event.getCode() == KeyCode.UP) {
             String prevCommand = historyGetter.navigateCommandHistory(-1);
             commandTextField.setText(prevCommand);
+            Platform.runLater(() -> commandTextField.end()); // Set cursor to end of line
         } else if (event.getCode() == KeyCode.DOWN) {
             String nextCommand = historyGetter.navigateCommandHistory(1);
             commandTextField.setText(nextCommand);
+            Platform.runLater(() -> commandTextField.end()); // Set cursor to end of line
         }
-        Platform.runLater(() -> commandTextField.end()); // Set cursor to end of line
 
 
     }

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -15,7 +15,7 @@ import seedu.address.commons.core.LogsCenter;
  */
 public class HelpWindow extends UiPart<Stage> {
 
-    public static final String USERGUIDE_URL = "https://se-education.org/addressbook-level3/UserGuide.html";
+    public static final String USERGUIDE_URL = "https://ay2526s1-cs2103t-f11-4.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
@@ -23,6 +23,9 @@ public class HelpWindow extends UiPart<Stage> {
 
     @FXML
     private Button copyButton;
+
+    @FXML
+    private Button openButton;
 
     @FXML
     private Label helpMessage;
@@ -98,5 +101,16 @@ public class HelpWindow extends UiPart<Stage> {
         final ClipboardContent url = new ClipboardContent();
         url.putString(USERGUIDE_URL);
         clipboard.setContent(url);
+    }
+
+    @FXML
+    private void openUserGuideLink() {
+        try {
+            // Opens a new browser tab with UserGuide Link and close the help window
+            java.awt.Desktop.getDesktop().browse(new java.net.URI(USERGUIDE_URL));
+            getRoot().close();
+        } catch (Exception e) {
+            logger.fine(e.getMessage());
+        }
     }
 }

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -31,6 +31,11 @@
               <Insets left="5.0" />
             </HBox.margin>
           </Button>
+          <Button fx:id="openButton" mnemonicParsing="false" onAction="#openUserGuideLink" text="Browse">
+            <HBox.margin>
+              <Insets left="5.0" />
+            </HBox.margin>
+          </Button>
         </children>
         <opaqueInsets>
           <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />


### PR DESCRIPTION
Closes: #88 

### CommandBox Fix
- Fixed the issue of cursor being stuck at the end of command box

### Better Help usage
- Redirects user to browser directly after clicking button
- Closes the help window after user clicks on the browse button in help

### Gradle Changes 
- Added explicit JavaFX dependency list and plugin (To resolve issues of non-default dependencies not found in Windows) 