### PR TITLE
Add logging for FilterCommand and FilterCommandParser

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -2,6 +2,9 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.tag.TagsContainTagPredicate;
@@ -21,6 +24,8 @@ public class FilterCommand extends Command {
             + "Parameters: t/[TAG]...\n"
             + "Example: " + COMMAND_WORD + " t/ friends t/ colleague";
 
+    private static final Logger logger = LogsCenter.getLogger(FilterCommand.class);
+
     private final TagsContainTagPredicate predicate;
 
     /**
@@ -30,14 +35,21 @@ public class FilterCommand extends Command {
     public FilterCommand(TagsContainTagPredicate predicate) {
         requireNonNull(predicate);
         this.predicate = predicate;
+        logger.fine("FilterCommand object created with predicate: " + predicate);
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+        logger.info("Executing filter command");
+
         model.updateFilteredPersonList(predicate);
+        int filteredListSize = model.getFilteredPersonList().size();
+
+        logger.info("Filter command executed successfully. Number of persons found: " + filteredListSize);
+
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, filteredListSize));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -4,6 +4,9 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
@@ -14,6 +17,8 @@ import seedu.address.model.tag.TagsContainTagPredicate;
  */
 public class FilterCommandParser implements Parser<FilterCommand> {
 
+    private static final Logger logger = LogsCenter.getLogger(FilterCommandParser.class);
+
     /**
      * Parses the given {@code String} of arguments in the context of the FilterCommand
      * and returns a FilterCommand object for execution.
@@ -22,6 +27,8 @@ public class FilterCommandParser implements Parser<FilterCommand> {
      */
     public FilterCommand parse(String args) throws ParseException {
         requireNonNull(args);
+        logger.fine("Parsing filter command with arguments: " + args);
+
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TAG);
         checkValidTokens(argMultimap);
 
@@ -31,6 +38,9 @@ public class FilterCommandParser implements Parser<FilterCommand> {
                                                        .distinct()
                                                        .map(token -> new Tag(token))
                                                        .toList());
+
+        logger.info("Successfully parsed filter command with tags: "
+                + argMultimap.getAllValues(PREFIX_TAG));
 
         return new FilterCommand(predicate);
     }
@@ -55,10 +65,12 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         String errorMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE);
 
         if (!argMultimap.getValue(PREFIX_TAG).isPresent()) {
+            logger.warning("No tags provided in filter command");
             throw new ParseException(errorMessage);
         }
 
         if (!argMultimap.getPreamble().isEmpty()) {
+            logger.warning("Preamble found in filter command");
             throw new ParseException(errorMessage);
         }
 
@@ -66,11 +78,13 @@ public class FilterCommandParser implements Parser<FilterCommand> {
                                               .anyMatch(tagName -> tagName.isEmpty());
 
         if (containsEmptyTag) {
+            logger.warning("Empty tag found in filter command");
             throw new ParseException(errorMessage);
         }
 
         if (argMultimap.getAllValues(PREFIX_TAG).stream()
                        .anyMatch(tagName -> !Tag.isValidTagName(tagName))) {
+            logger.warning("Invalid tag name found in filter command");
             throw new ParseException(errorMessage);
         }
     }


### PR DESCRIPTION
There was a lack of logging for FilterCommand and FilterCommandParser

Added logging for these two classes.
Logging is included for most methods which are involved in the processing of a command.

Closes: #94 