### PR TITLE
Ban the reserved value of email and company to avoid confusing users

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -324,7 +324,7 @@ addbasic n/Rahul s/o Kumar p/91112222
     - **Note:** Common official patterns like `s/o` (son of) and `d/o` (daughter of) are **allowed** and safe, because `s/` and `d/` are not reserved prefixes.
 
 
-### **Adding a contact with complete details** : `add`
+### Adding a contact with complete details: `add`
 
 Adds a contact with full information including name, phone, email, company, and optional tags.
 
@@ -336,7 +336,9 @@ Adds a contact with full information including name, phone, email, company, and 
       Similarly, you may use `.` or `-` in names if needed (e.g. `Rahul s.o. Kumar`, `Tan-Kumar`).
   * **Phone** (`p/`) - At least 3 digits
   * **Email** (`e/`) - Valid email address (e.g., name@company.com)
+    * The specific email address of `unknown@example.com` is reserved and cannot use as your input
   * **Company** (`c/`) - Company or organization name
+    * The specific company of `N/A` is reserved and cannot use as your input
   * **Tags** (`t/`) - Optional labels like "client", "colleague" or "vendor" (add as many as you want)
 
 **What you need to know:**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -74,6 +74,11 @@ public class ParserUtil {
     public static Company parseCompany(String company) throws ParseException {
         requireNonNull(company);
         String trimmedCompany = company.trim();
+
+        if (trimmedCompany.equalsIgnoreCase("N/A")) {
+            throw new ParseException("The company name 'N/A' is reserved and cannot be used.");
+        }
+
         if (!Company.isValidCompany(trimmedCompany)) {
             throw new ParseException(Company.MESSAGE_CONSTRAINTS);
         }
@@ -89,6 +94,11 @@ public class ParserUtil {
     public static Email parseEmail(String email) throws ParseException {
         requireNonNull(email);
         String trimmedEmail = email.trim();
+
+        if (trimmedEmail.equalsIgnoreCase("unknown@example.com")) {
+            throw new ParseException("The email 'unknown@example.com' is reserved and cannot be used.");
+        }
+
         if (!Email.isValidEmail(trimmedEmail)) {
             throw new ParseException(Email.MESSAGE_CONSTRAINTS);
         }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -30,6 +30,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.TypicalPersons.BOB;
 
@@ -37,6 +38,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Company;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -193,4 +195,15 @@ public class AddCommandParserTest {
                 + COMPANY_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
+
+    @Test
+    public void parseEmail_reservedEmail_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseEmail("unknown@example.com"));
+    }
+
+    @Test
+    public void parseCompany_reservedCompany_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseCompany("N/A"));
+    }
+
 }


### PR DESCRIPTION
**Enhancement of the adding-feature**
Since in the UI-layer, when implementing `addbasic`, we set the `unknown@example.com` and `N/A` as the placeholder of the required field in `Person` and hide them to user. If the user coincidently input this two value when implementing `add` command, the UI would show the value to make user confused

Solution: Ban users to input these two values:
* Both inputs are case-insensitive