### PR TITLE
Add explanation of placeholder in UG for add-command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -324,7 +324,7 @@ addbasic n/Rahul s/o Kumar p/91112222
     - **Note:** Common official patterns like `s/o` (son of) and `d/o` (daughter of) are **allowed** and safe, because `s/` and `d/` are not reserved prefixes.
 
 
-### **Adding a contact with complete details** : `add`
+### Adding a contact with complete details: `add`
 
 Adds a contact with full information including name, phone, email, company, and optional tags.
 
@@ -336,7 +336,11 @@ Adds a contact with full information including name, phone, email, company, and 
       Similarly, you may use `.` or `-` in names if needed (e.g. `Rahul s.o. Kumar`, `Tan-Kumar`).
   * **Phone** (`p/`) - At least 3 digits
   * **Email** (`e/`) - Valid email address (e.g., name@company.com)
+    * * We *do not recommend* entering `unknown@example.com`, as it is used internally as an `invisible` placeholder when you do not specify an email for your contact.
+    * * If you enter that specific value, you will not see the field in your FastCard interface.
   * **Company** (`c/`) - Company or organization name
+    * * We *do not recommend* entering `N/A`, as it is used internally as an `invisible` placeholder when you do not specify an email for your contact.
+    * * If you enter that specific value, you will not see the field in your FastCard interface.
   * **Tags** (`t/`) - Optional labels like "client", "colleague" or "vendor" (add as many as you want)
 
 **What you need to know:**


### PR DESCRIPTION
**Enhancement of the adding-feature**
Since in the UI-layer, when implementing `addbasic`, we set the `unknown@example.com` and `N/A` as the placeholder of the required field in `Person` and hide them to user. If the user coincidently input this two value when implementing `add` command, the UI would show the value to make user confused

*Solution*
Since banning users to input these two values would refer to a mount of code changes of the current application, we added the explanation of placeholder and instruction for them under the sector `Add`